### PR TITLE
Abandon Integer-s to avoid JSON exception

### DIFF
--- a/lib/src/main/java/com/sweetzpot/stravazpot/upload/model/UploadStatus.java
+++ b/lib/src/main/java/com/sweetzpot/stravazpot/upload/model/UploadStatus.java
@@ -4,13 +4,13 @@ import com.google.gson.annotations.SerializedName;
 
 public class UploadStatus {
 
-    @SerializedName("id") private int id;
+    @SerializedName("id") private long id;
     @SerializedName("external_id") private String externalID;
     @SerializedName("error") private String error;
     @SerializedName("status") private String status;
-    @SerializedName("activity_id") private Integer activityID;
+    @SerializedName("activity_id") private Long activityID;
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 
@@ -26,7 +26,7 @@ public class UploadStatus {
         return status;
     }
 
-    public Integer getActivityID() {
+    public Long getActivityID() {
         return activityID;
     }
 }


### PR DESCRIPTION
Getting

```
com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: Expected an int but was 2242280993 at line 1 column 17 path $.id
        at com.google.gson.internal.bind.TypeAdapters$7.read(TypeAdapters.java:245)
        at com.google.gson.internal.bind.TypeAdapters$7.read(TypeAdapters.java:235)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:129)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:220)
        at retrofit2.converter.gson.GsonResponseBodyConverter.convert(GsonResponseBodyConverter.java:37)
        at retrofit2.converter.gson.GsonResponseBodyConverter.convert(GsonResponseBodyConverter.java:25)
        at retrofit2.ServiceMethod.toResponse(ServiceMethod.java:117)
        at retrofit2.OkHttpCall.parseResponse(OkHttpCall.java:211)
        at retrofit2.OkHttpCall.execute(OkHttpCall.java:174)
        at retrofit2.ExecutorCallAdapterFactory$ExecutorCallbackCall.execute(ExecutorCallAdapterFactory.java:89)
        at com.sweetzpot.stravazpot.common.api.StravaAPI.execute(StravaAPI.java:26)
        at com.sweetzpot.stravazpot.upload.request.UploadFileRequest.execute(UploadFileRequest.java:91)
```

when uploading activity to Strava, as activityID 2242280993 is greater than Integer.MAX_VALUE in Java. 

Longs should be used instead of Integers to avoid this problem?