### PR TITLE
Enable TLS 1.2 on pre-lollipop devices

### DIFF
--- a/lib/src/main/java/com/sweetzpot/stravazpot/common/api/Config.java
+++ b/lib/src/main/java/com/sweetzpot/stravazpot/common/api/Config.java
@@ -15,6 +15,7 @@ import com.sweetzpot.stravazpot.club.model.Membership;
 import com.sweetzpot.stravazpot.club.model.SkillLevel;
 import com.sweetzpot.stravazpot.club.model.SportType;
 import com.sweetzpot.stravazpot.club.model.Terrain;
+import com.sweetzpot.stravazpot.common.api.security.OKHttpUtil;
 import com.sweetzpot.stravazpot.common.model.Coordinates;
 import com.sweetzpot.stravazpot.common.model.Distance;
 import com.sweetzpot.stravazpot.common.model.Gender;
@@ -87,7 +88,7 @@ public abstract class Config {
             builder.addInterceptor(interceptor);
         }
 
-        OkHttpClient client = builder.build();
+        OkHttpClient client = OKHttpUtil.enableTls12OnPreLollipop(builder).build();
 
         Retrofit retrofit = new Retrofit.Builder().baseUrl(baseURL)
                 .client(client)

--- a/lib/src/main/java/com/sweetzpot/stravazpot/common/api/security/OKHttpUtil.java
+++ b/lib/src/main/java/com/sweetzpot/stravazpot/common/api/security/OKHttpUtil.java
@@ -1,0 +1,4 @@
+package com.sweetzpot.stravazpot.common.api.security;
+
+public class OKHttpUtil {
+}

--- a/lib/src/main/java/com/sweetzpot/stravazpot/common/api/security/OKHttpUtil.java
+++ b/lib/src/main/java/com/sweetzpot/stravazpot/common/api/security/OKHttpUtil.java
@@ -1,4 +1,63 @@
 package com.sweetzpot.stravazpot.common.api.security;
 
+import android.os.Build;
+import android.util.Log;
+
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
+
 public class OKHttpUtil {
+
+
+    /**
+     * Enables TLSv1.2 protocol (which is disabled by default)
+     * on pre-Lollipop devices, as well as on Lollipop, because some issues can take place on Samsung devices.
+     *
+     * @param client OKHtp client builder
+     * @return
+     */
+    public static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
+            try {
+                SSLContext sc = SSLContext.getInstance("TLSv1.2");
+                sc.init(null, null, null);
+
+                TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init((KeyStore) null);
+                TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+                if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+                    throw new IllegalStateException("Unexpected default trust managers:"
+                            + Arrays.toString(trustManagers));
+                }
+                X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
+
+                client.sslSocketFactory(new Tls12SocketFactory(sc.getSocketFactory()), trustManager);
+
+                ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                        .tlsVersions(TlsVersion.TLS_1_2)
+                        .build();
+
+                List<ConnectionSpec> specs = new ArrayList<>();
+                specs.add(cs);
+                specs.add(ConnectionSpec.COMPATIBLE_TLS);
+                specs.add(ConnectionSpec.CLEARTEXT);
+
+                client.connectionSpecs(specs);
+            } catch (Exception exc) {
+                Log.e("OkHttpTLSCompat", "Error while setting TLS 1.2", exc);
+            }
+        }
+        return client;
+    }
 }

--- a/lib/src/main/java/com/sweetzpot/stravazpot/common/api/security/Tls12SocketFactory.java
+++ b/lib/src/main/java/com/sweetzpot/stravazpot/common/api/security/Tls12SocketFactory.java
@@ -1,6 +1,61 @@
 package com.sweetzpot.stravazpot.common.api.security;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 public class Tls12SocketFactory extends SSLSocketFactory {
+    private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+    final SSLSocketFactory delegate;
+
+    public Tls12SocketFactory(SSLSocketFactory base) {
+        this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+        if (s instanceof SSLSocket) {
+            ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+        }
+        return s;
+    }
 }

--- a/lib/src/main/java/com/sweetzpot/stravazpot/common/api/security/Tls12SocketFactory.java
+++ b/lib/src/main/java/com/sweetzpot/stravazpot/common/api/security/Tls12SocketFactory.java
@@ -1,0 +1,6 @@
+package com.sweetzpot.stravazpot.common.api.security;
+
+import javax.net.ssl.SSLSocketFactory;
+
+public class Tls12SocketFactory extends SSLSocketFactory {
+}


### PR DESCRIPTION
I encountered a problem using your library on Android 4.4 devices, since Strava only accepts TLS1.2, which is not activated by default on Android 4.

I did not want to use GooglePlay Services to update it (my app is also distributed in china, where GPS is not available), I then add to modify the OkHttp client configuration you use with Retrofit.

I did this using this StackOverflow answer : 
https://stackoverflow.com/questions/45202267/android-4-1-to-4-4-kitkat-enable-tls-1-2-for-api

I slightly modified it to avoid usage of deprecated sslFactory setter on client, as described in OkHttp javadoc.